### PR TITLE
Issue #54: Improvement: Add emergency stop on communication line failure

### DIFF
--- a/KPI_Rover/Communication/ProtocolHandler.c
+++ b/KPI_Rover/Communication/ProtocolHandler.c
@@ -160,6 +160,14 @@ static void dispatch_get_imu(void)
 	UARTTransport_send(sendBuffer, 53);
 }
 
+static void ProtocolHandler_emergencyStop(void)
+{
+	ulDatabase_setInt32(MOTOR_FL_SETPOINT, 0);
+	ulDatabase_setInt32(MOTOR_RL_SETPOINT, 0);
+	ulDatabase_setInt32(MOTOR_FR_SETPOINT, 0);
+	ulDatabase_setInt32(MOTOR_RR_SETPOINT, 0);
+}
+
 static const void (*dispatch_table[])(void) = {
 	dispatch_not_a_command,
 	dispatch_get_api_version,
@@ -177,7 +185,11 @@ void ProtocolHandler_processTask(void *d)
 	UARTTransport_init();
 
 	for ( ; ; ) {
-		UARTTransport_receive(recvBuffer, &recvSize);
+		if (!UARTTransport_receive(recvBuffer, &recvSize))
+		{
+			ProtocolHandler_emergencyStop();
+			continue;
+		}
 
 		if (recvBuffer[0] >= LEN(dispatch_table))
 			continue;

--- a/KPI_Rover/Communication/UARTTransport.c
+++ b/KPI_Rover/Communication/UARTTransport.c
@@ -57,14 +57,22 @@ void UARTTransport_init(void)
 	(void) osThreadNew(UARTTransport_sendTask, NULL, &ta);
 }
 
-void UARTTransport_receive(uint8_t * const buf, uint8_t * const size)
+bool UARTTransport_receive(uint8_t * const buf, uint8_t * const size)
 {
 	static uint8_t recvBuffer[UART_TRANSPORT_RECV_BUFFER_SIZE];
 
-	for ( ; osMessageQueueGet(recvQ, recvBuffer, NULL, 50) != osOK; drvUart_restart_receiver());
+	if (osMessageQueueGet(recvQ, recvBuffer, NULL, 50) != osOK)
+	{
+		return false;
+	}
+	else
+	{
+		*size = recvBuffer[0] - 1;
+		memcpy(buf, recvBuffer + 1, *size);
 
-	*size = recvBuffer[0] - 1;
-	memcpy(buf, recvBuffer + 1, *size);
+		return true;
+	}
+
 }
 
 void UARTTransport_send(const uint8_t * const buf, const uint8_t size)

--- a/KPI_Rover/Communication/UARTTransport.h
+++ b/KPI_Rover/Communication/UARTTransport.h
@@ -2,12 +2,13 @@
 #define __UART_TRANSPORT_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #define UART_TRANSPORT_RECV_BUFFER_SIZE 32
 #define UART_TRANSPORT_SEND_BUFFER_SIZE 64
 
 void UARTTransport_init(void);
-void UARTTransport_receive(uint8_t * const buf, uint8_t * const size);
+bool UARTTransport_receive(uint8_t * const buf, uint8_t * const size);
 void UARTTransport_send(const uint8_t * const buf, const uint8_t size);
 
 #endif /* __UART_TRANSPORT_H */


### PR DESCRIPTION
This PR changes `ITransport::receive()` interface return type from `void` to `bool` as it is now able to fail. `ProtocolHandler` is now aware of this change and is able to take actions defined in `void ProtocolHandler_emergencyStop(void)` function upon a failure. Currently it only stops the motors to prevent uncontrollable driving.